### PR TITLE
Add flag for kRA->logit(kRA) and add associated test

### DIFF
--- a/pyActigraphy/metrics/metrics.py
+++ b/pyActigraphy/metrics/metrics.py
@@ -1362,7 +1362,9 @@ class MetricsMixin(object):
 
         return pAR, pAR_weights
 
-    def kRA(self, threshold, start=None, period=None, frac=.3, it=0):
+    def kRA(
+        self, threshold, start=None, period=None, frac=.3, it=0, logit=False
+    ):
         r"""Rest->Activity transition probability
 
         Weighted average value of pRA(t) within the constant regions, defined
@@ -1381,12 +1383,16 @@ class MetricsMixin(object):
         period: str, optional
             Time period for the calculation of pRA.
             Default is None.
-        frac: float
+        frac: float, optional
             Fraction of the data used when estimating each value.
             Default is 0.3.
-        it: int
+        it: int, optional
             Number of residual-based reweightings to perform.
             Default is 0.
+        logit: bool, optional
+            If True, the kRA value is logit-transformed (ln(p/1-p)). Useful
+            when kRA is used in a regression model.
+            Default is False.
 
         Returns
         -------
@@ -1422,9 +1428,11 @@ class MetricsMixin(object):
             frac=frac,
             it=it
             )
-        return kRA
+        return np.log(kRA/(1-kRA)) if logit else kRA
 
-    def kAR(self, threshold, start=None, period=None, frac=.3, it=0):
+    def kAR(
+        self, threshold, start=None, period=None, frac=.3, it=0, logit=False
+    ):
         r"""Rest->Activity transition probability
 
         Weighted average value of pAR(t) within the constant regions, defined
@@ -1449,6 +1457,10 @@ class MetricsMixin(object):
         it: int
             Number of residual-based reweightings to perform.
             Default is 0.
+        logit: bool, optional
+            If True, the kRA value is logit-transformed (ln(p/1-p)). Useful
+            when kRA is used in a regression model.
+            Default is False.
 
         Returns
         -------
@@ -1484,7 +1496,7 @@ class MetricsMixin(object):
             frac=frac,
             it=it
             )
-        return kAR
+        return np.log(kAR/(1-kAR)) if logit else kAR
 
 
 class ForwardMetricsMixin(object):

--- a/pyActigraphy/tests/test_kra.py
+++ b/pyActigraphy/tests/test_kra.py
@@ -10,7 +10,7 @@ frequency = pd.Timedelta(sampling_period, unit='s')
 start_time = '01/01/2018 00:00:00'
 N = 30240*sampling_period
 period = pd.Timedelta(N, unit='s')
-seq_prob = 0.7
+seq_prob = 0.7311  # ~ e/e+1
 seq_max_length = 50
 
 sequences = generate_series(
@@ -39,6 +39,11 @@ seq = pyActigraphy.io.BaseRaw(
 def test_kra_sequences():
 
     assert seq.kRA(0) == pytest.approx(seq_prob, rel=0.01)
+
+
+def test_kra_logit():
+
+    assert seq.kRA(0, logit=True) == pytest.approx(1.0, rel=0.04)
 
 
 def test_kar_sequences():


### PR DESCRIPTION
Add possibility to return a logit-transformed kRA/kAR instead of the kRA/kAR values. Useful when using the kRA/AR as dependent variable in a linear regression model.