### PR TITLE
Hotfix/bba

### DIFF
--- a/pyActigraphy/io/bba/bba.py
+++ b/pyActigraphy/io/bba/bba.py
@@ -285,7 +285,7 @@ class RawBBA(BaseRaw):
                 + ' from input filename: {}'.format(input_fname)
             )
 
-        if not re.match(
+        if not re.search(
             pattern=r'{}.(cwa|CWA|bin)(\.gz)?'.format(input_basename),
             string=os.path.basename(meta_data['file-name'])
         ):

--- a/pyActigraphy/io/bba/bba.py
+++ b/pyActigraphy/io/bba/bba.py
@@ -270,7 +270,7 @@ class RawBBA(BaseRaw):
             meta_data = json.load(file)
 
         # check filename consistency:
-        # - META-DATA: file-name = 'basename'.cwa[.gz]
+        # - META-DATA: file-name = 'basename'.(cwa|CWA|bin)[.gz]
         # - INPUT DATA: input_fname = 'basename'-timeSeries.csv[.gz]
 
         match_basename = re.match(
@@ -286,7 +286,7 @@ class RawBBA(BaseRaw):
             )
 
         if not re.match(
-            pattern=r'{}.(cwa|CWA)(\.gz)?'.format(input_basename),
+            pattern=r'{}.(cwa|CWA|bin)(\.gz)?'.format(input_basename),
             string=os.path.basename(meta_data['file-name'])
         ):
             raise ValueError(

--- a/pyActigraphy/tests/data/sample-summary-wrong-name.json
+++ b/pyActigraphy/tests/data/sample-summary-wrong-name.json
@@ -1,5 +1,5 @@
 {
-    "file-name": "nosample.cwa.gz",
+    "file-name": "wrongname.cwa.gz",
     "file-size": 72765789,
     "file-deviceID": 13110,
     "calibration-xOffset(g)": -0.05122435978970148,


### PR DESCRIPTION
Hot fix for the BBA reader (Issue #151):
- Modify regex pattern to account for json summary files from converted GENEACTIV bin files.
- Modify code to add more flexibility in the comparison of the "input file" path information contained in the json summary file and the actual "timeSerie.csv" file.