### PR TITLE
Make the accelerometer dependency optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
     install_requires=[
         'joblib', 'lmfit', 'pandas', 'plotly', 'numba', 'numpy', 'pyexcel',
         'pyexcel-ods3', 'pyexcel-xlsx', 'scipy', 'spm1d', 'statsmodels>=0.10',
-        'stochastic>=0.6.0', 'accelerometer>=6.2.2'
+        'stochastic>=0.6.0'
     ],  # Optional
 
     # Data files included in your packages that need to be installed.


### PR DESCRIPTION
This dependency currently causes tricky conflicts. Importing it dynamically replaces the hard dependency with an optional one that only users with BBA files need to install.

See also https://github.com/ghammad/pyActigraphy/pull/160 for the other approach to this problem.