### PR TITLE
Fix Crespo issues with modern Pandas versions

### DIFF
--- a/pyActigraphy/sleep/scoring_base.py
+++ b/pyActigraphy/sleep/scoring_base.py
@@ -65,7 +65,7 @@ def _padded_data(data, value, periods, frequency):
             end=data.index[0],
             periods=periods,
             freq=date_offset,
-            closed='left'
+            inclusive='left'
         ),
         dtype=data.dtype
     )
@@ -75,7 +75,7 @@ def _padded_data(data, value, periods, frequency):
             start=data.index[-1],
             periods=periods,
             freq=date_offset,
-            closed='right'
+            inclusive='right'
         ),
         dtype=data.dtype
     )
@@ -1384,12 +1384,10 @@ class ScoringMixin(object):
         # symmetrical anymore. In the regions (start, start+alpha/2,
         # the median needs to be calculate by hand.
         # The range is start, start+alpha as the window is centered.
-        median_start = x_sp.iloc[0:L_w].expanding(
-                center=True
-            ).median()
+        median_start = x_sp.iloc[0:L_w].expanding().median()
         median_end = x_sp.iloc[-L_w-1:-1].sort_index(
                 ascending=False
-            ).expanding(center=True).median()[::-1]
+            ).expanding().median()[::-1]
 
         # replace values in the original x_fa series with the new values
         # within the range (start, start+alpha/2) only.

--- a/setup.py
+++ b/setup.py
@@ -106,9 +106,9 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'joblib', 'lmfit', 'pandas', 'plotly', 'numba', 'numpy', 'pyexcel',
-        'pyexcel-ods3', 'pyexcel-xlsx', 'scipy', 'spm1d', 'statsmodels>=0.10',
-        'stochastic>=0.6.0', 'accelerometer>=6.2.2'
+        'joblib', 'lmfit', 'pandas>=1.4.0', 'plotly', 'numba', 'numpy',
+        'pyexcel', 'pyexcel-ods3', 'pyexcel-xlsx', 'scipy', 'spm1d',
+        'statsmodels>=0.10', 'stochastic>=0.6.0', 'accelerometer>=6.2.2'
     ],  # Optional
 
     # Data files included in your packages that need to be installed.


### PR DESCRIPTION
The `pd.date_range()` argument `closed` was deprecated in Pandas 1.4 with `inclusive` as the preferred replacement. See https://github.com/pandas-dev/pandas/issues/40245.

The `expanding()` argument `center` was deprecated in Pandas 1.1 as "non-sensical" with no replacement. See https://github.com/pandas-dev/pandas/issues/20647. As discussed in that issue, I believe the use of `center=True` is a bug in the Crespo implementation, and removing it is the right thing to do.

Both of these deprecated arguments were removed in Pandas 2.0, so this change is needed to make Crespo work with recent Pandas versions.

To ensure no breakage because of this change, I'm adding a `pandas>=1.4.0` dependency version constraint to ensure the presence of the `inclusive` argument to `pd.date_range()`.